### PR TITLE
Fix package limits in setup.py for installation in pvcompare

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         "pandas >= 0.24.1",
         "numpy",
         "matplotlib",
-        "xarray==0.15.0",
-        "feedinlib==0.0.12"
+        "xarray",
+        "feedinlib==0.1.0rc2"
     ],
 )


### PR DESCRIPTION
Changes in this PR:
- Change feedinlib version and delete limit of xarray